### PR TITLE
fix for deprecation messages

### DIFF
--- a/lib/jwave/updater.rb
+++ b/lib/jwave/updater.rb
@@ -65,7 +65,7 @@ module Jwave
     # @return [Array]
     def load_xml
       last_modified = xml = ''
-      open(XML_URL) do |f|
+      URI.open(XML_URL) do |f|
         last_modified = f.last_modified
         xml = f.readlines.join
       end


### PR DESCRIPTION
This fixes following deprecation messages:

```
lib/jwave/updater.rb:68: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```
