### PR TITLE
Add GitHub Actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,10 @@ updates:
       patterns:
         - "rubocop"
         - "rubocop-*"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+    timezone: Asia/Tokyo
+  open-pull-requests-limit: 10
 


### PR DESCRIPTION
## Summary
- dependabot設定にGitHub Actionsエコシステムを追加
- GitHub Actionsの依存関係も自動アップデートされるようになる

## Test plan
- dependabot.ymlの設定が正しく適用されることを確認
- GitHub Actionsのアップデートプルリクエストが作成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)